### PR TITLE
default value for final var, used in xml_parse

### DIFF
--- a/IXR_Library.php
+++ b/IXR_Library.php
@@ -211,6 +211,7 @@ class IXR_Message
         xml_set_character_data_handler($this->_parser, 'cdata');
         $chunk_size = 262144; // 256Kb, parse in chunks to avoid the RAM usage on very large messages
         do {
+            $final = false;
             if (strlen($this->message) <= $chunk_size) {
                 $final = true;
             }


### PR DESCRIPTION
Creates an error in case of large data retrieve, like https://kb.ubivox.com/api/latest/html/methods.html#mailer.list_subscriptions