### PR TITLE
fix deprecated and lineendings

### DIFF
--- a/IXR_Library.php
+++ b/IXR_Library.php
@@ -115,7 +115,7 @@ class IXR_Value
                 return '<double>'.$this->data.'</double>';
                 break;
             case 'string':
-                return '<string>'.htmlspecialchars($this->data).'</string>';
+                return '<string>'.htmlspecialchars(($this->data ? $this->data : '')).'</string>';
                 break;
             case 'array':
                 $return = '<array><data>'."\n";
@@ -600,6 +600,7 @@ class IXR_Client
     var $message = false;
     var $debug = false;
     var $timeout;
+    var $headers = [];
 
     // Storage place for an error message
     var $error = false;
@@ -1293,6 +1294,7 @@ class IXR_ClassServer extends IXR_Server
 {
     var $_objects;
     var $_delim;
+    var $_delimiter;
 
     function __construct($delim = '.', $wait = false)
     {

--- a/ubivox_api.php
+++ b/ubivox_api.php
@@ -17,7 +17,7 @@ class UbivoxAPI {
     var $password;
     var $url;
     var $encoding;
-    
+
     function __construct($username, $password, $url, $encoding="utf-8") {
         $this->username = $username;
         $this->password = $password;
@@ -42,7 +42,7 @@ class UbivoxAPI {
         curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($c, CURLOPT_POSTFIELDS, $post);
         curl_setopt($c, CURLOPT_HEADER, true);
-        curl_setopt($c, CURLOPT_CONNECTTIMEOUT, 15);
+        curl_setopt($c, CURLOPT_CONNECTTIMEOUT, 30);
         curl_setopt($c, CURLOPT_HTTPHEADER, array(
             "Content-Type: text/xml; charset=".$this->encoding,
             "Expect:"


### PR DESCRIPTION
fixing Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in ubivox-api-php-master/IXR_Library.php on line 118